### PR TITLE
changed code A display from mixed british to white - british

### DIFF
--- a/codesystems/CodeSystem-CareConnect-EthnicCategory-1.xml
+++ b/codesystems/CodeSystem-CareConnect-EthnicCategory-1.xml
@@ -5,10 +5,10 @@
 		<valueUri value="http://www.datadictionary.nhs.uk/data_dictionary/data_field_notes/p/pds/pds_ethnic_category_code_de.asp?shownav=0"/>
 	</extension>
 	<url value="https://fhir.hl7.org.uk/STU3/CodeSystem/CareConnect-EthnicCategory-1"/>
-	<version value="1.1.0"/>
+	<version value="1.2.0"/>
 	<name value="Care Connect Ethnic Category"/>
 	<status value="draft"/>
-	<date value="2018-11-02T00:00:00+00:00"/>
+	<date value="2023-08-30T00:00:00+00:00"/>
 	<publisher value="HL7 UK"/>
 	<description value="A CodeSystem to identify the ethnicity of a Person, as specified by the Person. This vocabulary describes a persons ethnic category, it is an extension of the Ethnic Category Code described in the NHS Data Model and Dictionary."/>
 	<caseSensitive value="true"/>

--- a/codesystems/CodeSystem-CareConnect-EthnicCategory-1.xml
+++ b/codesystems/CodeSystem-CareConnect-EthnicCategory-1.xml
@@ -15,7 +15,7 @@
 	<content value="complete"/>
 	<concept>
 		<code value="A"/>
-		<display value="British, Mixed British"/>
+		<display value="White - British"/>
 	</concept>
 	<concept>
 		<code value="B"/>


### PR DESCRIPTION
Category 'A' should have been White- British as per DSC Notice 02/2001 and [dmd ](https://www.datadictionary.nhs.uk/data_elements/ethnic_category.html?hl=ethnic)